### PR TITLE
Fix #8: Make embedding model accessible across all computers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+tempCodeRunnerFile.py
+tempCodeRunnerFile.py

--- a/app.py
+++ b/app.py
@@ -6,10 +6,7 @@ from sklearn.metrics.pairwise import cosine_similarity
 app = Flask(__name__)
 
 # ---- Load local BGE-base ----
-model_name = "D:/VolumeEStuff/SEM 5/NLP/case study/bge-base-en-v1.5"
-word_embedding_model = models.Transformer(model_name)
-pooling_model = models.Pooling(word_embedding_model.get_word_embedding_dimension())
-model = SentenceTransformer(modules=[word_embedding_model, pooling_model])
+model = SentenceTransformer("BAAI/bge-base-en-v1.5")
 
 # Load embeddings once at startup
 conn = sqlite3.connect("questions.db")


### PR DESCRIPTION
Fixes #8 

## Changes
- Updated `app.py` to use `BAAI/bge-base-en-v1.5` with auto-download
- Added `.gitignore` to exclude temporary files

## How it works
- Model downloads automatically (~438MB) on first run
- Uses Hugging Face Hub's caching mechanism
- Eliminates need for pre-cached models on new machines

## Testing
- Tested locally with fresh model download
- App runs successfully after initial model fetch